### PR TITLE
imports: support for ESM projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 7.1.0
+
+- Can now use .imports.cts or .imports.cjs files (see imports-config rule).
+
 # 7.0.0
 
 - Breaking: @typescript-eslint/no-floating-promises rule has been renamed to @qawolf/no-floating-promises

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Use this in your project:
 
 ## Configure imports
 
-Create `.imports.js/ts` files anywhere in your codebase to configure how the code in those directories needs to be imported.
+Create `.imports.js/ts/cjs/cts` files anywhere in your codebase to configure how the code in those directories needs to be imported. If using this in an ESM project (`type` is `"module"` in `package.json`), then the extensions must be `.cjs` or `.cts`.
 
 If the directory in question contains somewhat independent code modules underneath, export an `absoluteImportPrefix` variable to ensure that the subdirectories are not imported with relative paths:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qawolf/eslint-plugin",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qawolf/eslint-plugin",
-      "version": "7.0.0",
+      "version": "7.1.0",
       "license": "ISC",
       "dependencies": {
         "@denis-sokolov/eslint-plugin": "^18.1.1",

--- a/package.json
+++ b/package.json
@@ -51,5 +51,5 @@
     "verify": "npm run tsc:check && npm run lint && npm run test"
   },
   "type": "commonjs",
-  "version": "7.0.0"
+  "version": "7.1.0"
 }

--- a/src/rules/imports-config-valid.ts
+++ b/src/rules/imports-config-valid.ts
@@ -5,7 +5,9 @@ import { readdirSync } from "fs";
 export default defineRule(function (context) {
   const isConfig =
     context.physicalFilename.endsWith("/.imports.js") ||
-    context.physicalFilename.endsWith("/.imports.ts");
+    context.physicalFilename.endsWith("/.imports.ts") ||
+    context.physicalFilename.endsWith("/.imports.cjs") ||
+    context.physicalFilename.endsWith("/.imports.cts");
   if (!isConfig) return {};
   const directory = dirname(context.physicalFilename);
 

--- a/src/rules/imports-config.ts
+++ b/src/rules/imports-config.ts
@@ -33,6 +33,8 @@ export default defineImportsRule(function (details) {
   const paths = [
     cwd + "/" + boundaryPrefix + ".imports.ts",
     cwd + "/" + boundaryPrefix + ".imports.js",
+    cwd + "/" + boundaryPrefix + ".imports.cts",
+    cwd + "/" + boundaryPrefix + ".imports.cjs",
   ];
   for (const path of paths) {
     if (!existsSync(path)) continue;

--- a/src/rules/imports-prefix/getDesiredAbsoluteImport.ts
+++ b/src/rules/imports-prefix/getDesiredAbsoluteImport.ts
@@ -15,7 +15,12 @@ function getAbsoluteImportPrefixForDir(
     return pref + basename(dir) + "/";
   }
 
-  const paths = [dir + "/.imports.ts", dir + "/.imports.js"];
+  const paths = [
+    dir + "/.imports.ts",
+    dir + "/.imports.js",
+    dir + "/.imports.cts",
+    dir + "/.imports.cjs",
+  ];
   for (const path of paths) {
     if (!existsSync(path)) continue;
     // eslint-disable-next-line @typescript-eslint/no-var-requires -- ESLint does not support async rules, we must use a sync require. Under the hood this file runs in CommonJS anyway.


### PR DESCRIPTION
These changes allow this package to work in an ESM project by adding support for `.cjs` and `.cts` files when configuring the imports rules.

`Error [ERR_REQUIRE_ESM]: Must use import to load ES Module` error happens whenever this package tries to load a `.imports.ts` file.

Because it uses `require` to load the files and this is happening in functions that cannot be async, we can't use `await import`. Eventually it would be good to rewrite more extensively so that `.ts` and `.js` files can be imported directly when this is used in an ESM project, but for now it's simple and effective to add support for `.cjs` and `.cts` extensions, which resolves the error.