### PR TITLE
Make imports/path work with our unit tests

### DIFF
--- a/src/imports/path.ts
+++ b/src/imports/path.ts
@@ -19,6 +19,13 @@ export const moduleFromPath = function ({
   projectDirectory: string;
 }): string {
   if (!path.startsWith(projectDirectory)) {
+    if (path === "<input>") {
+      // Hack for our tests to have some value
+      if (process.env.NODE_ENV === "test") return "";
+      throw Error(
+        "The path <input> is unrecognized. If you’re running this plugin’s unit tests, check the workaround above this error.",
+      );
+    }
     throw Error(
       `The path ${path} does not start with the project directory ${projectDirectory}`,
     );


### PR DESCRIPTION
Today imports/path crashes when we use it in rules in unit tests. This adds a workaround and enables us to write more unit tests.