### PR TITLE
Enable `n/no-process-env` rule as an error

### DIFF
--- a/src/config/other.ts
+++ b/src/config/other.ts
@@ -82,6 +82,12 @@ export const otherRules = {
       ignores: ["dynamicImport", "modules"],
     },
   ],
+  "n/no-process-env": [
+    "error",
+    {
+      allowedVariables: ["NEXT_RUNTIME"],
+    },
+  ],
 
   "no-restricted-globals": [
     "error",

--- a/src/config/overrides.ts
+++ b/src/config/overrides.ts
@@ -56,4 +56,27 @@ export const overrides = [
       ],
     },
   },
+  // We normally disallow process.env, but it's fine to use it in test files,
+  // config files, scripts, etc., and also in the `env.ts` file.
+  {
+    files: [
+      "*.test.ts",
+      "*.test.tsx",
+      "*.type-test.ts",
+      "*.type-test.tsx",
+      "**/test/**",
+      "**/.jest/**",
+      "**/env/**/*.ts",
+      "**/env.ts",
+      "**/environment.ts",
+      "**/next-config/**",
+      "**/webpack/**",
+      "scripts/**",
+      "jest.config.*",
+      "webpack.config.*",
+    ],
+    rules: {
+      "n/no-process-env": "off",
+    },
+  },
 ] satisfies Linter.Config["overrides"];

--- a/src/config/overrides.ts
+++ b/src/config/overrides.ts
@@ -23,6 +23,9 @@ export const overrides = [
 
       // Allow test files to use dev dependencies
       "n/no-unpublished-import": "off",
+
+      // Allow test files to use process.env
+      "n/no-process-env": "off",
     },
   },
   {
@@ -54,29 +57,6 @@ export const overrides = [
           ({ selector }) => selector !== "ExportDefaultDeclaration",
         ),
       ],
-    },
-  },
-  // We normally disallow process.env, but it's fine to use it in test files,
-  // config files, scripts, etc., and also in the `env.ts` file.
-  {
-    files: [
-      "*.test.ts",
-      "*.test.tsx",
-      "*.type-test.ts",
-      "*.type-test.tsx",
-      "**/test/**",
-      "**/.jest/**",
-      "**/env/**/*.ts",
-      "**/env.ts",
-      "**/environment.ts",
-      "**/next-config/**",
-      "**/webpack/**",
-      "scripts/**",
-      "jest.config.*",
-      "webpack.config.*",
-    ],
-    rules: {
-      "n/no-process-env": "off",
     },
   },
 ] satisfies Linter.Config["overrides"];


### PR DESCRIPTION
We have long had a guideline to access `process.env` only in an `env.ts` file that validates it with `envalid`, and only in `apps` projects, not in packages. Exceptions are config files, Jest files, and scripts.

This enables the [n/no-process-env rule](https://github.com/eslint-community/eslint-plugin-n/blob/master/docs/rules/no-process-env.md), with exceptions for file patterns where direct `process.env` access should be allowed. This doesn't directly address the problem of disallowing it entirely in the platform `packages` folder (you could fool it with an `env.ts` file in a package), but it is a big improvement from having no linting at all.

I have verified this configuration change in the platform repo. There are a handful of places we need to fix or disable the rule, which I am working on a PR for.